### PR TITLE
fix: hero section typo & add dynamic icons

### DIFF
--- a/components/layout/sections/hero.tsx
+++ b/components/layout/sections/hero.tsx
@@ -21,7 +21,7 @@ export const HeroSection = () => {
 
           <div className="max-w-screen-md mx-auto text-center text-4xl md:text-6xl font-bold">
             <h1>
-              Experiece the
+              Experience the
               <span className="text-transparent px-2 bg-gradient-to-r from-[#D247BF] to-primary bg-clip-text">
                 Shadcn
               </span>

--- a/components/layout/sections/sponsors.tsx
+++ b/components/layout/sections/sponsors.tsx
@@ -4,6 +4,7 @@ import { Icon } from "@/components/ui/icon";
 import { Marquee } from "@devnomic/marquee";
 import "@devnomic/marquee/dist/index.css";
 import { icons } from "lucide-react";
+import { useTheme } from "next-themes";
 interface sponsorsProps {
   icon: string;
   name: string;
@@ -41,6 +42,8 @@ const sponsors: sponsorsProps[] = [
 ];
 
 export const SponsorsSection = () => {
+  const { theme } = useTheme();
+
   return (
     <section id="sponsors" className="max-w-[75%] mx-auto pb-24 sm:pb-32">
       <h2 className="text-lg md:text-xl text-center mb-6">
@@ -57,7 +60,7 @@ export const SponsorsSection = () => {
               <Icon
                 name={icon as keyof typeof icons}
                 size={32}
-                color="white"
+                color={`${theme === "light" ? "black" : "white"}`}
                 className="mr-2"
               />
               {name}


### PR DESCRIPTION
Fix:
- Typo in hero section for 'experience' written as 'experiece'

Add: 
- Add dynamic theme based color scheme for sponsor icons. (Sponsor icons weren't visible in light theme)