### PR TITLE
Localize hero section to Chinese and rebrand to CodeAlly

### DIFF
--- a/components/layout/sections/hero.tsx
+++ b/components/layout/sections/hero.tsx
@@ -21,22 +21,21 @@ export const HeroSection = () => {
 
           <div className="max-w-screen-md mx-auto text-center text-4xl md:text-6xl font-bold">
             <h1>
-              Experience the
-              <span className="text-transparent px-2 bg-gradient-to-r from-[#D247BF] to-primary bg-clip-text">
-                Shadcn
+              欢迎使用
+              <span className="text-transparent px-2 bg-gradient-to-r from-[#4ECDC4] to-[#2B6CB0] bg-clip-text">
+                CodeAlly
               </span>
-              landing page
+              — AI 驱动的开发平台
             </h1>
           </div>
 
           <p className="max-w-screen-sm mx-auto text-xl text-muted-foreground">
-            {`We're more than just a tool, we're a community of passionate
-            creators. Get access to exclusive resources, tutorials, and support.`}
+            从想法到上线，只需三步。不写代码、不装环境、不等排期。
           </p>
 
           <div className="space-y-4 md:space-y-0 md:space-x-4">
             <Button className="w-5/6 md:w-1/4 font-bold group/arrow">
-              Get Started
+              立即体验
               <ArrowRight className="size-5 ml-2 group-hover/arrow:translate-x-1 transition-transform" />
             </Button>
 


### PR DESCRIPTION
## Summary
Updated the hero section to support Chinese language and rebrand the landing page from Shadcn to CodeAlly, an AI-driven development platform.

## Key Changes
- **Localization**: Translated all hero section text from English to Chinese
  - Main heading: "Experience the Shadcn landing page" → "欢迎使用 CodeAlly — AI 驱动的开发平台"
  - Subheading: Updated to Chinese value proposition "从想法到上线，只需三步。不写代码、不装环境、不等排期。"
  - CTA button: "Get Started" → "立即体验"

- **Branding**: Updated gradient colors in the hero heading
  - Changed from purple/pink gradient (`from-[#D247BF] to-primary`) to teal/blue gradient (`from-[#4ECDC4] to-[#2B6CB0]`) to match CodeAlly brand identity

## Implementation Details
- All changes are contained within the hero section component
- Gradient color update reflects the new brand color scheme
- No structural changes to the component layout or styling approach

https://claude.ai/code/session_01KoC2br7hytdoJMgwu2Bqgx